### PR TITLE
Allow models given by abstract matrices

### DIFF
--- a/src/LinearCovarianceModels.jl
+++ b/src/LinearCovarianceModels.jl
@@ -106,7 +106,7 @@ struct LCModel{T1<:DP.AbstractPolynomialLike, T2<:Number}
     end
 end
 LCModel(Σ::Matrix) = LCModel(Σ, get_basis(Σ))
-LCModel(Σ::AbstractMatrix) = LCModel(Matrix(Σ))
+LCModel(Σ::AbstractMatrix) = LCModel(Matrix(Σ .+ false))
 
 function get_basis(Σ)
     vars = DP.variables(vec(Σ))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,11 @@ const LC = LinearCovarianceModels
 
         # throw for non-symmetric input
         @test_throws ArgumentError LCModel([x[1] x[1]; x[2] x[1]])
+
+        # handle special matrix types
+        @polyvar θ[1:7]
+        M = LCModel(SymTridiagonal(θ[1:4],θ[5:7]))
+        @test dim(M) == 7
     end
 
     @testset "mle system" begin


### PR DESCRIPTION
This fixes a bug which for example arises by working with special matrix types.

```
julia> using LinearCovarianceModels, DynamicPolynomials

julia> @polyvar θ[1:7];

julia> Σ  = SymTridiagonal(θ[1:4],θ[5:7])
4×4 SymTridiagonal{PolyVar{true},Array{PolyVar{true},1}}:
 θ₁  θ₅  ⋅   ⋅ 
 θ₅  θ₂  θ₆  ⋅ 
 ⋅   θ₆  θ₃  θ₇
 ⋅   ⋅   θ₇  θ₄

julia> Matrix(Σ)
ERROR: MethodError: no method matching PolyVar{true}(::Polynomial{true,Int64})
```